### PR TITLE
Minor Improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
   </developers>
 
   <properties>
-    <stack.version>3.5.0.Beta1</stack.version>
+    <stack.version>3.5.0</stack.version>
     <jmh.version>1.19</jmh.version>
   </properties>
 

--- a/src/main/java/com/julienviet/pgclient/PgResult.java
+++ b/src/main/java/com/julienviet/pgclient/PgResult.java
@@ -21,15 +21,39 @@ import io.vertx.codegen.annotations.VertxGen;
 
 import java.util.List;
 
+/**
+ * Represents the result of an operation on database.
+ * @param <T>
+ */
 @VertxGen
 public interface PgResult<T> extends Iterable<T> {
 
+  /**
+   * Get the number of the affected rows in the operation to this PgResult.
+   *
+   * @return the count of affected rows.
+   */
   int updatedCount();
 
+  /**
+   * Get the names of columns in the PgResult.
+   *
+   * @return the list of names of columns.
+   */
   List<String> columnsNames();
 
+  /**
+   * Get the number of rows in the PgResult.
+   *
+   * @return the count of rows.
+   */
   int size();
 
+  /**
+   * Get the iterator of the PgResult.
+   *
+   * @return the iterator.
+   */
   PgIterator<T> iterator();
 
 }


### PR DESCRIPTION
1. Add document for PgResult
2. Upgrade Vert.x Stack Version to 3.5.0 from 3.5.0 Beta1

After upgrading to 3.5.0, all unit tests have passed, and I made some fundamental tests on the main functions, it seems to work in a right way. But I didn't pay attention to the results of benchmark, maybe posting the comparison of  benchmark results in two stack versions is necessary?